### PR TITLE
Added additional source data check in input_l2cap_frame_flow_channel

### DIFF
--- a/os/net/mac/ble/ble-l2cap.c
+++ b/os/net/mac/ble/ble-l2cap.c
@@ -435,7 +435,19 @@ input_l2cap_frame_flow_channel(l2cap_channel_t *channel, uint8_t *data, uint16_t
     	return;
     }
 
+    if (2 > data_len - 4) {
+      LOG_WARN("l2cap_frame: source buffer not large enough");
+      /* Source buffer is not large enough to contain necessary data */
+      return;
+    }
+
     memcpy(&channel->rx_buffer.sdu_length, &data[4], 2);
+
+    if (payload_len > data_len - 6) {
+      LOG_WARN("l2cap_frame: source buffer not large enough");
+      /* Source buffer is not large enough to contain necessary data */
+      return;
+    }
 
     memcpy(channel->rx_buffer.sdu, &data[6], payload_len);
     channel->rx_buffer.current_index = payload_len;
@@ -449,6 +461,12 @@ input_l2cap_frame_flow_channel(l2cap_channel_t *channel, uint8_t *data, uint16_t
     	/* the current index plus the payload length may not be larger than 
 	 * the destination buffer */
     	return;
+    }
+
+    if (payload_len > data_len - 4) {
+      LOG_WARN("l2cap_frame: source buffer not large enough");
+      /* Source buffer is not large enough to contain necessary data */
+      return;
     }
 
     memcpy(&channel->rx_buffer.sdu[channel->rx_buffer.current_index], &data[4], payload_len);

--- a/os/net/mac/ble/ble-l2cap.c
+++ b/os/net/mac/ble/ble-l2cap.c
@@ -435,12 +435,6 @@ input_l2cap_frame_flow_channel(l2cap_channel_t *channel, uint8_t *data, uint16_t
     	return;
     }
 
-    if (2 > data_len - 4) {
-      LOG_WARN("l2cap_frame: source buffer not large enough");
-      /* Source buffer is not large enough to contain necessary data */
-      return;
-    }
-
     memcpy(&channel->rx_buffer.sdu_length, &data[4], 2);
 
     if (payload_len > data_len - 6) {

--- a/os/net/mac/ble/ble-l2cap.c
+++ b/os/net/mac/ble/ble-l2cap.c
@@ -429,19 +429,14 @@ input_l2cap_frame_flow_channel(l2cap_channel_t *channel, uint8_t *data, uint16_t
     memcpy(&frame_len, &data[0], 2);
     payload_len = frame_len - 2;
 
-    if(payload_len > BLE_L2CAP_NODE_MTU) {
-    	LOG_WARN("l2cap_frame: illegal L2CAP frame payload_len: %d\n", payload_len);
+    if (payload_len > BLE_L2CAP_NODE_MTU || payload_len > data_len - 6)
+    {
+      LOG_WARN("l2cap_frame: illegal L2CAP frame payload_len: %d\n", payload_len);
     	/* the payload length may not be larger than the destination buffer */
     	return;
     }
 
     memcpy(&channel->rx_buffer.sdu_length, &data[4], 2);
-
-    if (payload_len > data_len - 6) {
-      LOG_WARN("l2cap_frame: source buffer not large enough");
-      /* Source buffer is not large enough to contain necessary data */
-      return;
-    }
 
     memcpy(channel->rx_buffer.sdu, &data[6], payload_len);
     channel->rx_buffer.current_index = payload_len;
@@ -450,17 +445,11 @@ input_l2cap_frame_flow_channel(l2cap_channel_t *channel, uint8_t *data, uint16_t
     memcpy(&frame_len, &data[0], 2);
     payload_len = frame_len;
     
-    if(payload_len > BLE_L2CAP_NODE_MTU - channel->rx_buffer.current_index) {
+    if(payload_len > BLE_L2CAP_NODE_MTU - channel->rx_buffer.current_index || payload_len > data_len - 4) {
     	LOG_WARN("l2cap_frame: illegal L2CAP frame payload_len: %d\n", payload_len);
     	/* the current index plus the payload length may not be larger than 
 	 * the destination buffer */
     	return;
-    }
-
-    if (payload_len > data_len - 4) {
-      LOG_WARN("l2cap_frame: source buffer not large enough");
-      /* Source buffer is not large enough to contain necessary data */
-      return;
     }
 
     memcpy(&channel->rx_buffer.sdu[channel->rx_buffer.current_index], &data[4], payload_len);


### PR DESCRIPTION
The `input_l2cap_frame_flow_channel` does not properly verify the size of the provided source buffer when copying data into the `l2cap_channel_t` struct. This could lead to out of bounds reads using a crafted packet.

This PR fixes the issue by adding two checks before each copy that ensures the source data buffer has enough size to preform the copy.