### PR TITLE
Added check in ns_input

### DIFF
--- a/os/net/ipv6/uip-nd6.c
+++ b/os/net/ipv6/uip-nd6.c
@@ -187,7 +187,7 @@ ns_input(void)
 
   if (uip_l3_icmp_hdr_len + sizeof(uip_nd6_ns) > uip_len)
   {
-    LOG_ERR("Not enough space for cast");
+    LOG_ERR("Insufficient data for reading ND6 NS header fields");
     goto discard;
   }
 

--- a/os/net/ipv6/uip-nd6.c
+++ b/os/net/ipv6/uip-nd6.c
@@ -184,6 +184,13 @@ ns_input(void)
   UIP_STAT(++uip_stat.nd6.recv);
 
 #if UIP_CONF_IPV6_CHECKS
+
+  if (uip_l3_icmp_hdr_len + sizeof(uip_nd6_ns) > uip_len)
+  {
+    LOG_ERR("Not enough space for cast");
+    goto discard;
+  }
+
   if((UIP_IP_BUF->ttl != UIP_ND6_HOP_LIMIT) ||
      (uip_is_addr_mcast(&UIP_ND6_NS_BUF->tgtipaddr)) ||
      (UIP_ICMP_BUF->icode != 0)) {


### PR DESCRIPTION
The `ns_input` does not properly ensure the size of the data buffer is large enough when preforming a cast. This can lead to out of bounds reads with a crafted packet.

This PR fixes the issue by ensuring the header size plus the size of the struct does not exceed the data size.